### PR TITLE
#29 support for RealmModule annotation

### DIFF
--- a/library-base/build.gradle
+++ b/library-base/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     androidTestCompile "com.google.truth:truth:0.31"
     androidTestCompile 'io.reactivex.rxjava2:rxjava:2.1.4'
     androidTestCompile 'io.reactivex.rxjava2:rxandroid:2.0.1'
+    compile "org.jetbrains.kotlin:kotlin-reflect:1.1.1"
 
     testCompile 'junit:junit:4.12'
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"

--- a/library-base/src/main/java/com/vicpin/krealmextensions/RealmConfigStore.kt
+++ b/library-base/src/main/java/com/vicpin/krealmextensions/RealmConfigStore.kt
@@ -1,8 +1,13 @@
 package com.vicpin.krealmextensions
 
+import android.util.Log
 import io.realm.Realm
 import io.realm.RealmConfiguration
+import io.realm.RealmModel
 import io.realm.RealmObject
+import io.realm.annotations.RealmModule
+import kotlin.reflect.KClass
+import kotlin.reflect.full.isSubclassOf
 
 /**
  * Realm configuration store per class
@@ -10,33 +15,69 @@ import io.realm.RealmObject
  */
 class RealmConfigStore {
     companion object {
-        private var configMap: MutableMap<Class<out RealmObject>, RealmConfiguration> = HashMap()
+        var TAG = RealmConfigStore::class.java.simpleName
+        private var configMap: MutableMap<Class<out RealmModel>, RealmConfiguration> = HashMap()
 
-        fun <T : RealmObject> init(modelClass: Class<T>, realmCfg: RealmConfiguration) {
+        /**
+         * Initialize realm configuration for module.
+         */
+        fun initModule(module: Any, realmCfg: RealmConfiguration) {
+            Log.d(TAG, "Initialize classes from module ${module.javaClass.name}")
+            if (module::class.java.isAnnotationPresent(RealmModule::class.java)) {
+                var realmModuleAnnotation = module::class.java.getAnnotation(RealmModule::class.java)
+                if (realmModuleAnnotation.allClasses == true) {
+                    // todo use this config as default??
+                    // what if there is more modules with allClasses?
+                }
+                realmModuleAnnotation.classes.forEach { kclz ->
+                    try {
+                        if (kclz.isSubclassOf(RealmModel::class)) {
+                            val clz = kclz as KClass<RealmModel>
+                            init(clz.java, realmCfg)
+                        } else {
+                            Log.w(TAG, "Class not for Realm")
+                        }
+                    } catch (ex: Exception) {
+                        Log.e(TAG, "Error testing class in RealmModel for compatibility", ex)
+                    }
+                }
+            } else {
+                Log.w(TAG, "Module ${module.javaClass.name} is not RealmModule")
+            }
+        }
+
+        /**
+         * Initialize realm configuration for class
+         */
+        fun <T : RealmModel> init(modelClass: Class<T>, realmCfg: RealmConfiguration) {
+            Log.d(TAG, "Adding class $modelClass to realm ${realmCfg.realmFileName}")
             if (!configMap.containsKey(modelClass)) {
                 configMap.put(modelClass, realmCfg)
             }
         }
 
-        fun <T : RealmObject> fetchConfiguration(modelClass: Class<T>): RealmConfiguration? {
+        /**
+         * Fetches realm configuration for class.
+         */
+        fun <T : RealmModel> fetchConfiguration(modelClass: Class<T>): RealmConfiguration? {
             return configMap[modelClass]
         }
     }
 }
 
-fun <T : RealmObject> T.getRealmInstance() : Realm {
+fun <T : RealmObject> T.getRealmInstance(): Realm {
     return RealmConfigStore.fetchConfiguration(this::class.java)?.realm() ?: Realm.getDefaultInstance()
 }
 
-fun <T : RealmObject> getRealmInstance(clazz : Class<T>) : Realm {
+fun <T : RealmObject> getRealmInstance(clazz: Class<T>): Realm {
     return RealmConfigStore.fetchConfiguration(clazz)?.realm() ?: Realm.getDefaultInstance()
 }
 
-inline fun <reified D : RealmObject, T : Collection<D>> T.getRealmInstance() : Realm {
+inline fun <reified D : RealmObject, T : Collection<D>> T.getRealmInstance(): Realm {
     return RealmConfigStore.fetchConfiguration(D::class.java)?.realm() ?: Realm.getDefaultInstance()
 }
 
-inline fun <reified D : RealmObject> Array<D>.getRealmInstance() : Realm {
+inline fun <reified D : RealmObject> Array<D>.getRealmInstance(): Realm {
     return RealmConfigStore.fetchConfiguration(D::class.java)?.realm() ?: Realm.getDefaultInstance()
 }
 

--- a/sample/src/main/java/com/vicpin/kotlinrealmextensions/Application.kt
+++ b/sample/src/main/java/com/vicpin/kotlinrealmextensions/Application.kt
@@ -6,6 +6,7 @@ import com.vicpin.krealmextensions.RealmConfigStore
 
 import io.realm.Realm
 import io.realm.RealmConfiguration
+import io.realm.annotations.RealmModule
 
 /**
  * Created by victor on 2/1/17.
@@ -18,8 +19,17 @@ class Application : android.app.Application() {
 
         Realm.init(this)
         val userAddressConfig = RealmConfiguration.Builder().name("user-db").schemaVersion(1).deleteRealmIfMigrationNeeded().build()
-        RealmConfigStore.init(User::class.java, userAddressConfig)
+        // delete all data
+        Realm.deleteRealm(Realm.getDefaultConfiguration())
+        Realm.deleteRealm(userAddressConfig)
+
+        RealmConfigStore.initModule(UserModule(), userAddressConfig)
         RealmConfigStore.init(Address::class.java, userAddressConfig)
     }
-
 }
+
+/**
+ * Example Realm module
+ */
+@RealmModule(classes = arrayOf(User::class))
+class UserModule

--- a/sample/src/main/java/com/vicpin/kotlinrealmextensions/model/User.kt
+++ b/sample/src/main/java/com/vicpin/kotlinrealmextensions/model/User.kt
@@ -1,10 +1,12 @@
 package com.vicpin.kotlinrealmextensions.model
 
+import io.realm.RealmModel
 import io.realm.RealmObject
+import io.realm.annotations.RealmClass
 
 /**
  * Created by magillus on 8/14/2017.
  */
 open class User(var name: String? = null, var address: Address? = Address()) : RealmObject()
-
-open class Address(var street: String? = null, var city: String? = null, var zip: String? = null) : RealmObject()
+@RealmClass
+open class Address(var street: String? = null, var city: String? = null, var zip: String? = null) : RealmModel


### PR DESCRIPTION
#29 support for Realm Module annotation
There is big question what to do if the `allClasses` on module is added. I suggest that the configuration passed to `initModule` would be set as default replacing all defaults. - thoughts @vicpinm ?