### PR TITLE
Update realm version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.21'
+    ext.kotlin_version = '1.2.31'
     repositories {
         jcenter()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "io.realm:realm-gradle-plugin:4.3.1"
 
@@ -15,24 +15,11 @@ buildscript {
         // in the individual module build.gradle files
     }
 }
-apply plugin: 'kotlin'
 
 allprojects {
     repositories {
+        mavenCentral()
         jcenter()
         google()
     }
-}
-
-
-repositories {
-    mavenCentral()
-    jcenter()
-    google()
-}
-dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-}
-sourceSets {
-    main.java.srcDirs += 'src/main/kotlin'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "io.realm:realm-gradle-plugin:4.3.1"
+        classpath "io.realm:realm-gradle-plugin:5.0.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/library-base/build.gradle
+++ b/library-base/build.gradle
@@ -39,6 +39,6 @@ dependencies {
     androidTestImplementation "com.google.truth:truth:0.31"
     androidTestImplementation 'io.reactivex.rxjava2:rxjava:2.1.12'
     androidTestImplementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
-    kaptAndroidTest 'io.realm:realm-annotations:4.3.1'
-    kaptAndroidTest 'io.realm:realm-annotations-processor:4.3.1'
+    kaptAndroidTest 'io.realm:realm-annotations:5.0.0'
+    kaptAndroidTest 'io.realm:realm-annotations-processor:5.0.0'
 }

--- a/library-base/build.gradle
+++ b/library-base/build.gradle
@@ -6,8 +6,7 @@ apply from: 'maven-push.gradle'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.1'
-
+    buildToolsVersion '27.0.3'
     defaultConfig {
         minSdkVersion 15
         targetSdkVersion 27
@@ -23,31 +22,23 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-    sourceSets {
-        main.java.srcDirs += 'src/main/kotlin'
-    }
     packagingOptions {
         exclude 'META-INF/rxjava.properties'
         exclude 'META-INF/library-base_debug.kotlin_module'
     }
-
 }
 
 dependencies {
-    compileOnly 'io.reactivex.rxjava2:rxjava:2.1.4'
-    compileOnly 'io.reactivex.rxjava2:rxandroid:2.0.1'
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile 'com.android.support.test:runner:0.5'
-    androidTestCompile 'com.android.support.test:rules:0.5'
-    androidTestCompile "com.google.truth:truth:0.31"
-    androidTestCompile 'io.reactivex.rxjava2:rxjava:2.1.4'
-    androidTestCompile 'io.reactivex.rxjava2:rxandroid:2.0.1'
-
-    testCompile 'junit:junit:4.12'
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compileOnly 'io.reactivex.rxjava2:rxjava:2.1.12'
+    compileOnly 'io.reactivex.rxjava2:rxandroid:2.0.1'
+    testImplementation 'junit:junit:4.12'
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'com.android.support.test:rules:1.0.1'
+    androidTestImplementation "com.google.truth:truth:0.31"
+    androidTestImplementation 'io.reactivex.rxjava2:rxjava:2.1.12'
+    androidTestImplementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
     kaptAndroidTest 'io.realm:realm-annotations:4.3.1'
     kaptAndroidTest 'io.realm:realm-annotations-processor:4.3.1'
-}
-repositories {
-    mavenCentral()
 }

--- a/library-base/src/main/java/com/vicpin/krealmextensions/RealmExtensionsFlowable.kt
+++ b/library-base/src/main/java/com/vicpin/krealmextensions/RealmExtensionsFlowable.kt
@@ -54,7 +54,7 @@ private fun <T : RealmModel> T.flowableQuery(fieldName: List<String>? = null, or
         query?.invoke(realmQuery)
 
         val result = if (fieldName != null && order != null) {
-            realmQuery.findAllSortedAsync(fieldName.toTypedArray(), order.toTypedArray())
+            realmQuery.sort(fieldName.toTypedArray(), order.toTypedArray()).findAllAsync()
         } else {
             realmQuery.findAllAsync()
         }

--- a/library-base/src/main/java/com/vicpin/krealmextensions/RealmExtensionsSingle.kt
+++ b/library-base/src/main/java/com/vicpin/krealmextensions/RealmExtensionsSingle.kt
@@ -49,7 +49,7 @@ private fun <T : RealmModel> T.singleQuery(fieldName : List<String>? = null, ord
         query?.invoke(realmQuery)
 
         val result = if(fieldName != null && order != null ) {
-            realmQuery.findAllSortedAsync(fieldName.toTypedArray(), order.toTypedArray())
+            realmQuery.sort(fieldName.toTypedArray(), order.toTypedArray()).findAllAsync()
         }
         else {
             realmQuery.findAllAsync()

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'realm-android'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.1'
+    buildToolsVersion '27.0.3'
     defaultConfig {
         applicationId "com.vicpin.kotlinrealmextensions"
         minSdkVersion 15
@@ -27,12 +27,11 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:27.0.2'
-    testCompile 'junit:junit:4.12'
-    compile project(':library-base')
-    compile 'io.reactivex.rxjava2:rxjava:2.1.4'
-    compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
-
-
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation project(':library-base')
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation 'com.android.support:appcompat-v7:27.1.0'
+    implementation 'io.reactivex.rxjava2:rxjava:2.1.12'
+    implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
+    testImplementation 'junit:junit:4.12'
 }


### PR DESCRIPTION
Hi!
I want to update library to use it with Realm 5.0.0, but Realm 5.0.0 [has a breaking change](https://github.com/realm/realm-java/blob/master/CHANGELOG.md#breaking-changes): from version 4.3.0 method `findAllSorted` is deprecated and from version 5.0.0 it is removed.